### PR TITLE
HYDRAN-196: Extended API responses with organization number attribute

### DIFF
--- a/src/integration-test/resources/MessagingSettingsIT/__files/test01_senderInfoByDeparmentId/response.json
+++ b/src/integration-test/resources/MessagingSettingsIT/__files/test01_senderInfoByDeparmentId/response.json
@@ -1,5 +1,6 @@
 [
 	{
+		"organizationNumber": "161234567890",
 		"supportText": "Kontakta oss via e-post eller telefon",
 		"contactInformationUrl": "https://domain.tld/",
 		"contactInformationPhoneNumber": "101-22 11 40",

--- a/src/integration-test/resources/MessagingSettingsIT/__files/test04_callbackEmail/response.json
+++ b/src/integration-test/resources/MessagingSettingsIT/__files/test04_callbackEmail/response.json
@@ -1,3 +1,4 @@
 {
+	"organizationNumber": "161234567890",
 	"callbackEmail": "no-reply@localhost.local"
 }

--- a/src/integration-test/resources/MessagingSettingsIT/__files/test07_portalSettings/response.json
+++ b/src/integration-test/resources/MessagingSettingsIT/__files/test07_portalSettings/response.json
@@ -1,4 +1,5 @@
 {
+	"organizationNumber": "161234567890",
 	"municipalityId": "2281",
 	"departmentName": "dept44",
 	"snailMailMethod": "EMAIL"

--- a/src/integration-test/resources/MessagingSettingsIT/__files/test10_senderInfoByNamespace/response.json
+++ b/src/integration-test/resources/MessagingSettingsIT/__files/test10_senderInfoByNamespace/response.json
@@ -1,5 +1,6 @@
 [
 	{
+		"organizationNumber": "161234567890",
 		"supportText": "Kontakta oss via e-post eller telefon",
 		"contactInformationUrl": "https://domain.tld/",
 		"contactInformationPhoneNumber": "101-22 11 40",
@@ -8,6 +9,7 @@
 		"smsSender": "SENDER NAME"
 	},
 	{
+		"organizationNumber": "160987654321",
 		"supportText": "Kontakta oss via e-post eller telefon",
 		"contactInformationUrl": "https://domain.tld/",
 		"contactInformationPhoneNumber": "101-22 11 40",

--- a/src/integration-test/resources/MessagingSettingsIT/__files/test12_senderInfoByNamespaceAndDepartmentName/response.json
+++ b/src/integration-test/resources/MessagingSettingsIT/__files/test12_senderInfoByNamespaceAndDepartmentName/response.json
@@ -1,5 +1,6 @@
 [
 	{
+		"organizationNumber": "161234567890",
 		"supportText": "Kontakta oss via e-post eller telefon",
 		"contactInformationUrl": "https://domain.tld/",
 		"contactInformationPhoneNumber": "101-22 11 40",

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -185,6 +185,7 @@ paths:
         description: Department ID
         required: true
         schema:
+          minLength: 1
           type: string
         example: SKM
       responses:
@@ -349,9 +350,9 @@ components:
             type: object
         status:
           $ref: "#/components/schemas/StatusType"
-        title:
-          type: string
         detail:
+          type: string
+        title:
           type: string
     StatusType:
       type: object
@@ -484,9 +485,9 @@ components:
             type: object
         status:
           $ref: "#/components/schemas/StatusType"
-        title:
-          type: string
         detail:
+          type: string
+        title:
           type: string
         suppressed:
           type: array
@@ -531,6 +532,10 @@ components:
     SenderInfoResponse:
       type: object
       properties:
+        organizationNumber:
+          type: string
+          description: Organization number of the organization connected to the information
+          example: "162021005489"
         supportText:
           type: string
           description: Descriptive support text
@@ -559,6 +564,10 @@ components:
     CallbackEmailResponse:
       type: object
       properties:
+        organizationNumber:
+          type: string
+          description: Organization number of the organization connected to the information
+          example: "162021005489"
         callbackEmail:
           type: string
           description: Callback e-mail address
@@ -567,6 +576,10 @@ components:
     PortalSettingsResponse:
       type: object
       properties:
+        organizationNumber:
+          type: string
+          description: Organization number of the organization connected to the information
+          example: "162021005489"
         municipalityId:
           type: string
           description: Municipality ID
@@ -582,7 +595,5 @@ components:
           enum:
           - EMAIL
           - SC_ADMIN
-          - SC_ADMIN
-          - EMAIL
       description: PortalSettings response
   securitySchemes: {}

--- a/src/main/java/se/sundsvall/messagingsettings/api/MessagingSettingsResource.java
+++ b/src/main/java/se/sundsvall/messagingsettings/api/MessagingSettingsResource.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -70,7 +71,7 @@ class MessagingSettingsResource {
 	})
 	ResponseEntity<CallbackEmailResponse> getCallbackEmail(
 		@Parameter(name = "municipalityId", description = "Municipality ID", example = "2281") @ValidMunicipalityId @PathVariable(name = "municipalityId") final String municipalityId,
-		@Parameter(name = "departmentId", description = "Department ID", example = "SKM") @PathVariable(name = "departmentId") final String departmentId) {
+		@Parameter(name = "departmentId", description = "Department ID", example = "SKM") @PathVariable(name = "departmentId") @NotBlank final String departmentId) {
 		return ok(messagingSettingsService.getCallbackEmailByMunicipalityIdAndDepartmentId(municipalityId, departmentId));
 	}
 

--- a/src/main/java/se/sundsvall/messagingsettings/api/model/CallbackEmailResponse.java
+++ b/src/main/java/se/sundsvall/messagingsettings/api/model/CallbackEmailResponse.java
@@ -1,13 +1,21 @@
 package se.sundsvall.messagingsettings.api.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Builder(setterPrefix = "with")
 @Schema(description = "CallbackEmail response")
 public class CallbackEmailResponse {
+
+	@Schema(description = "Organization number of the organization connected to the information", example = "162021005489")
+	private String organizationNumber;
 
 	@Schema(description = "Callback e-mail address", example = "no-reply@domain.tld")
 	private String callbackEmail;

--- a/src/main/java/se/sundsvall/messagingsettings/api/model/PortalSettingsResponse.java
+++ b/src/main/java/se/sundsvall/messagingsettings/api/model/PortalSettingsResponse.java
@@ -1,14 +1,22 @@
 package se.sundsvall.messagingsettings.api.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import se.sundsvall.messagingsettings.integration.db.entity.enums.SnailMailMethod;
+import lombok.NoArgsConstructor;
+import se.sundsvall.messagingsettings.enums.SnailMailMethod;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Builder(setterPrefix = "with")
 @Schema(description = "PortalSettings response")
 public class PortalSettingsResponse {
+
+	@Schema(description = "Organization number of the organization connected to the information", example = "162021005489")
+	private String organizationNumber;
 
 	@Schema(description = "Municipality ID", example = "2281")
 	private String municipalityId;
@@ -16,8 +24,6 @@ public class PortalSettingsResponse {
 	@Schema(description = "Department name", example = "SKM")
 	private String departmentName;
 
-	@Schema(description = "Method of delivery", example = "EMAIL", allowableValues = {
-		"SC_ADMIN", "EMAIL"
-	})
+	@Schema(description = "Method of delivery", example = "EMAIL")
 	private SnailMailMethod snailMailMethod;
 }

--- a/src/main/java/se/sundsvall/messagingsettings/api/model/SenderInfoResponse.java
+++ b/src/main/java/se/sundsvall/messagingsettings/api/model/SenderInfoResponse.java
@@ -1,13 +1,21 @@
 package se.sundsvall.messagingsettings.api.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Builder(setterPrefix = "with")
 @Schema(description = "SenderInfo response")
 public class SenderInfoResponse {
+
+	@Schema(description = "Organization number of the organization connected to the information", example = "162021005489")
+	private String organizationNumber;
 
 	@Schema(description = "Descriptive support text", example = "Kontakta oss via epost eller telefon")
 	private String supportText;

--- a/src/main/java/se/sundsvall/messagingsettings/enums/SnailMailMethod.java
+++ b/src/main/java/se/sundsvall/messagingsettings/enums/SnailMailMethod.java
@@ -1,0 +1,5 @@
+package se.sundsvall.messagingsettings.enums;
+
+public enum SnailMailMethod {
+	EMAIL, SC_ADMIN
+}

--- a/src/main/java/se/sundsvall/messagingsettings/integration/db/entity/MessagingSettingsEntity.java
+++ b/src/main/java/se/sundsvall/messagingsettings/integration/db/entity/MessagingSettingsEntity.java
@@ -20,7 +20,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.TimeZoneStorage;
 import org.hibernate.annotations.TimeZoneStorageType;
 import org.hibernate.annotations.UpdateTimestamp;
-import se.sundsvall.messagingsettings.integration.db.entity.enums.SnailMailMethod;
+import se.sundsvall.messagingsettings.enums.SnailMailMethod;
 
 @Entity
 @Table(name = "messaging_settings", indexes = {

--- a/src/main/java/se/sundsvall/messagingsettings/integration/db/entity/enums/SnailMailMethod.java
+++ b/src/main/java/se/sundsvall/messagingsettings/integration/db/entity/enums/SnailMailMethod.java
@@ -1,5 +1,0 @@
-package se.sundsvall.messagingsettings.integration.db.entity.enums;
-
-public enum SnailMailMethod {
-	EMAIL, SC_ADMIN
-}

--- a/src/main/java/se/sundsvall/messagingsettings/integration/db/mapper/EntityMapper.java
+++ b/src/main/java/se/sundsvall/messagingsettings/integration/db/mapper/EntityMapper.java
@@ -14,12 +14,13 @@ public class EntityMapper {
 	public static SenderInfoResponse toSenderInfo(final MessagingSettingsEntity entity) {
 		return ofNullable(entity)
 			.map(e -> SenderInfoResponse.builder()
-				.withSupportText(e.getSupportText())
 				.withContactInformationUrl(e.getContactInformationUrl())
 				.withContactInformationPhoneNumber(e.getContactInformationPhoneNumber())
 				.withContactInformationEmail(e.getContactInformationEmail())
 				.withContactInformationEmailName(e.getContactInformationEmailName())
+				.withOrganizationNumber(e.getOrganizationNumber())
 				.withSmsSender(e.getSmsSender())
+				.withSupportText(e.getSupportText())
 				.build())
 			.orElse(null);
 	}
@@ -28,6 +29,7 @@ public class EntityMapper {
 		return ofNullable(entity)
 			.map(e -> CallbackEmailResponse.builder()
 				.withCallbackEmail(e.getCallbackEmail())
+				.withOrganizationNumber(e.getOrganizationNumber())
 				.build())
 			.orElse(null);
 	}
@@ -35,8 +37,9 @@ public class EntityMapper {
 	public static PortalSettingsResponse toPortalSettings(final MessagingSettingsEntity entity) {
 		return ofNullable(entity)
 			.map(e -> PortalSettingsResponse.builder()
-				.withMunicipalityId(e.getMunicipalityId())
 				.withDepartmentName(e.getDepartmentName())
+				.withMunicipalityId(e.getMunicipalityId())
+				.withOrganizationNumber(e.getOrganizationNumber())
 				.withSnailMailMethod(e.getSnailMailMethod())
 				.build())
 			.orElse(null);

--- a/src/test/java/se/sundsvall/messagingsettings/api/MessagingSettingsResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/messagingsettings/api/MessagingSettingsResourceFailureTest.java
@@ -1,0 +1,100 @@
+package se.sundsvall.messagingsettings.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.zalando.problem.Status.BAD_REQUEST;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.zalando.problem.violations.ConstraintViolationProblem;
+import org.zalando.problem.violations.Violation;
+import se.sundsvall.messagingsettings.Application;
+import se.sundsvall.messagingsettings.service.MessagingSettingsService;
+
+@SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
+@ActiveProfiles("junit")
+class MessagingSettingsResourceFailureTest {
+
+	@MockitoBean
+	private MessagingSettingsService mockMessagingSettingsService;
+
+	@Autowired
+	private WebTestClient webTestClient;
+
+	@Test
+	void getSenderInfoReturnsBadRequest() {
+		final var response = webTestClient.get()
+			.uri(uriBuilder -> uriBuilder.path("/{municipalityId}/sender-info").build(Map.of("municipalityId", "9999")))
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult().getResponseBody();
+
+		assertThat(response.getStatus()).isEqualTo(BAD_REQUEST);
+		assertThat(response.getTitle()).isEqualTo("Constraint Violation");
+		assertThat(response.getViolations()).hasSize(1)
+			.extracting(
+				Violation::getField,
+				Violation::getMessage)
+			.contains(tuple(
+				"getSenderInfo.municipalityId",
+				"not a valid municipality ID"));
+
+		verifyNoInteractions(mockMessagingSettingsService);
+	}
+
+	@Test
+	void getCallbackEmailReturnsBadRequest() {
+		final var response = webTestClient.get()
+			.uri(uriBuilder -> uriBuilder.path("/{municipalityId}/{departmentId}/callback-email").build(Map.of("municipalityId", "9999", "departmentId", " ")))
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult().getResponseBody();
+
+		assertThat(response.getStatus()).isEqualTo(BAD_REQUEST);
+		assertThat(response.getTitle()).isEqualTo("Constraint Violation");
+		assertThat(response.getViolations()).hasSize(2)
+			.extracting(
+				Violation::getField,
+				Violation::getMessage)
+			.containsExactlyInAnyOrder(
+				tuple(
+					"getCallbackEmail.municipalityId",
+					"not a valid municipality ID"),
+				tuple(
+					"getCallbackEmail.departmentId",
+					"must not be blank"));
+
+		verifyNoInteractions(mockMessagingSettingsService);
+	}
+
+	@Test
+	void getPortalSettingsReturnsBadRequest() {
+		final var response = webTestClient.get()
+			.uri(uriBuilder -> uriBuilder.path("/{municipalityId}/portal-settings").build(Map.of("municipalityId", "9999")))
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult().getResponseBody();
+
+		assertThat(response.getStatus()).isEqualTo(BAD_REQUEST);
+		assertThat(response.getTitle()).isEqualTo("Constraint Violation");
+		assertThat(response.getViolations()).hasSize(1)
+			.extracting(
+				Violation::getField,
+				Violation::getMessage)
+			.contains(tuple(
+				"getPortalSettings.municipalityId",
+				"not a valid municipality ID"));
+
+		verifyNoInteractions(mockMessagingSettingsService);
+	}
+}

--- a/src/test/java/se/sundsvall/messagingsettings/api/MessagingSettingsResourceTest.java
+++ b/src/test/java/se/sundsvall/messagingsettings/api/MessagingSettingsResourceTest.java
@@ -1,23 +1,28 @@
 package se.sundsvall.messagingsettings.api;
 
+import static java.util.Optional.ofNullable;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import org.zalando.problem.Problem;
 import se.sundsvall.messagingsettings.Application;
+import se.sundsvall.messagingsettings.api.model.CallbackEmailResponse;
+import se.sundsvall.messagingsettings.api.model.PortalSettingsResponse;
 import se.sundsvall.messagingsettings.api.model.SenderInfoResponse;
+import se.sundsvall.messagingsettings.enums.SnailMailMethod;
 import se.sundsvall.messagingsettings.service.MessagingSettingsService;
 
 @SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
@@ -30,44 +35,91 @@ class MessagingSettingsResourceTest {
 	@Autowired
 	private WebTestClient webTestClient;
 
-	@Test
-	void getSenderInfoReturnsOK() {
+	private static Stream<Arguments> senderInfoParameterProvider() {
+		return Stream.of(
+			Arguments.of(null, null, null),
+			Arguments.of("departmentId", null, null),
+			Arguments.of(null, "departmentName", "namespace"),
+			Arguments.of(null, null, "namespace"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("senderInfoParameterProvider")
+	void getSenderInfoReturnsOK(String departmentId, String departmentName, String namespace) {
 		final var municipalityId = "2281";
-		final var departmentId = "dep";
 		final var senderInfoResponse = SenderInfoResponse.builder()
-			.withSupportText("text")
-			.withContactInformationUrl("url")
-			.withContactInformationPhoneNumber("phone number")
-			.withContactInformationEmail("email")
-			.withSmsSender("sender name")
+			.withSupportText("supportText")
+			.withContactInformationUrl("contactInformationUrl")
+			.withContactInformationPhoneNumber("contactInformationPhoneNumber")
+			.withContactInformationEmail("contactInformationEmail")
+			.withOrganizationNumber("organizationNumber")
+			.withSmsSender("smsSender")
 			.build();
 
-		when(mockMessagingSettingsService.getSenderInfo(municipalityId, departmentId, null, null))
-			.thenReturn(List.of(senderInfoResponse));
+		when(mockMessagingSettingsService.getSenderInfo(municipalityId, departmentId, departmentName, namespace)).thenReturn(List.of(senderInfoResponse));
 
 		webTestClient.get()
-			.uri(uriBuilder -> uriBuilder
-				.path("/{municipalityId}/sender-info")
-				.queryParam("departmentId", departmentId)
-				.build(Map.of("municipalityId", municipalityId)))
+			.uri(uriBuilder -> {
+				final var builder = uriBuilder.path("/{municipalityId}/sender-info");
+				ofNullable(departmentId).ifPresent(v -> builder.queryParam("departmentId", v));
+				ofNullable(departmentName).ifPresent(v -> builder.queryParam("departmentName", v));
+				ofNullable(namespace).ifPresent(v -> builder.queryParam("namespace", v));
+				return builder.build(Map.of("municipalityId", municipalityId));
+			})
 			.exchange()
 			.expectStatus().isOk()
 			.expectBodyList(SenderInfoResponse.class)
 			.contains(senderInfoResponse);
 
-		verify(mockMessagingSettingsService).getSenderInfo(municipalityId, departmentId, null, null);
+		verify(mockMessagingSettingsService).getSenderInfo(municipalityId, departmentId, departmentName, namespace);
 		verifyNoMoreInteractions(mockMessagingSettingsService);
 	}
 
 	@Test
-	void getSenderInfoReturnsBadRequest() {
-		final var municipalityId = "9999";
-		webTestClient.get()
-			.uri(uriBuilder -> uriBuilder.path("/{municipalityId}/sender-info").build(Map.of("municipalityId", municipalityId)))
-			.exchange()
-			.expectStatus().isEqualTo(BAD_REQUEST)
-			.expectBody(Problem.class);
+	void getCallbackEmail() {
+		final var municipalityId = "2281";
+		final var departmentId = "123";
+		final var callbackEmailResponse = CallbackEmailResponse.builder()
+			.withCallbackEmail("callbackEmail")
+			.withOrganizationNumber("organizationNumber")
+			.build();
 
-		verifyNoInteractions(mockMessagingSettingsService);
+		when(mockMessagingSettingsService.getCallbackEmailByMunicipalityIdAndDepartmentId(municipalityId, departmentId)).thenReturn(callbackEmailResponse);
+
+		webTestClient.get()
+			.uri(uriBuilder -> uriBuilder.path("/{municipalityId}/{departmentId}/callback-email").build(Map.of("municipalityId", municipalityId, "departmentId", departmentId)))
+			.exchange()
+			.expectStatus().isOk()
+			.expectBody(CallbackEmailResponse.class)
+			.isEqualTo(callbackEmailResponse);
+
+		verify(mockMessagingSettingsService).getCallbackEmailByMunicipalityIdAndDepartmentId(municipalityId, departmentId);
+		verifyNoMoreInteractions(mockMessagingSettingsService);
+	}
+
+	@Test
+	void getPortalSettings() {
+		final var municipalityId = "2281";
+		final var loginName = "loginName";
+		final var portalSettingsResponse = PortalSettingsResponse.builder()
+			.withDepartmentName("departmentName")
+			.withMunicipalityId("municipalityId")
+			.withOrganizationNumber("organizationNumber")
+			.withSnailMailMethod(SnailMailMethod.SC_ADMIN)
+			.build();
+
+		when(mockMessagingSettingsService.getUser()).thenReturn(loginName);
+		when(mockMessagingSettingsService.getPortalSettings(municipalityId, loginName)).thenReturn(portalSettingsResponse);
+
+		webTestClient.get()
+			.uri(uriBuilder -> uriBuilder.path("/{municipalityId}/portal-settings").build(Map.of("municipalityId", municipalityId)))
+			.exchange()
+			.expectStatus().isOk()
+			.expectBody(PortalSettingsResponse.class)
+			.isEqualTo(portalSettingsResponse);
+
+		verify(mockMessagingSettingsService).getUser();
+		verify(mockMessagingSettingsService).getPortalSettings(municipalityId, loginName);
+		verifyNoMoreInteractions(mockMessagingSettingsService);
 	}
 }

--- a/src/test/java/se/sundsvall/messagingsettings/api/model/CallbackEmailResponseTest.java
+++ b/src/test/java/se/sundsvall/messagingsettings/api/model/CallbackEmailResponseTest.java
@@ -1,27 +1,46 @@
 package se.sundsvall.messagingsettings.api.model;
 
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 class CallbackEmailResponseTest {
 
 	@Test
+	void testBean() {
+		assertThat(CallbackEmailResponse.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
 	void builderAndGetters() {
 		final var callbackEmail = "no-reply@domain.tld";
+		final var organizationNumber = "organizationNumber";
 
 		final var result = CallbackEmailResponse.builder()
 			.withCallbackEmail(callbackEmail)
+			.withOrganizationNumber(organizationNumber)
 			.build();
 
-		assertThat(result).isInstanceOf(CallbackEmailResponse.class);
+		assertThat(result).isInstanceOf(CallbackEmailResponse.class).hasNoNullFieldsOrProperties();
 		assertThat(result.getCallbackEmail()).isEqualTo(callbackEmail);
+		assertThat(result.getOrganizationNumber()).isEqualTo(organizationNumber);
 	}
 
 	@Test
 	void builderAndGetters_noValues() {
-		final var result = CallbackEmailResponse.builder().build();
-
-		assertThat(result).hasAllNullFieldsOrProperties();
+		assertThat(CallbackEmailResponse.builder().build()).hasAllNullFieldsOrProperties();
+		assertThat(new CallbackEmailResponse()).hasAllNullFieldsOrProperties();
 	}
 }

--- a/src/test/java/se/sundsvall/messagingsettings/api/model/PortalSettingsResponseTest.java
+++ b/src/test/java/se/sundsvall/messagingsettings/api/model/PortalSettingsResponseTest.java
@@ -1,37 +1,61 @@
 package se.sundsvall.messagingsettings.api.model;
 
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
-import se.sundsvall.messagingsettings.integration.db.entity.enums.SnailMailMethod;
+import se.sundsvall.messagingsettings.enums.SnailMailMethod;
 
 class PortalSettingsResponseTest {
 
 	@Test
+	void testBean() {
+		assertThat(PortalSettingsResponse.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
 	void builderAndGetters() {
-		final var municipalityId = "2281";
 		final var departmentName = "dept44";
+		final var municipalityId = "2281";
+		final var organizationNumber = "organizationNumber";
 		final var snailMailMethod = SnailMailMethod.EMAIL;
 
 		final var result = PortalSettingsResponse.builder()
-			.withMunicipalityId(municipalityId)
 			.withDepartmentName(departmentName)
+			.withMunicipalityId(municipalityId)
+			.withOrganizationNumber(organizationNumber)
 			.withSnailMailMethod(snailMailMethod)
 			.build();
 
 		assertThat(result)
 			.isInstanceOf(PortalSettingsResponse.class)
 			.hasNoNullFieldsOrProperties()
-			.extracting(PortalSettingsResponse::getMunicipalityId,
+			.extracting(
 				PortalSettingsResponse::getDepartmentName,
+				PortalSettingsResponse::getMunicipalityId,
+				PortalSettingsResponse::getOrganizationNumber,
 				PortalSettingsResponse::getSnailMailMethod)
-			.containsExactly(municipalityId, departmentName, snailMailMethod);
+			.containsExactly(
+				departmentName,
+				municipalityId,
+				organizationNumber,
+				snailMailMethod);
 	}
 
 	@Test
 	void builderAndGetters_noValues() {
-		final var entity = PortalSettingsResponse.builder().build();
-
-		assertThat(entity).hasAllNullFieldsOrProperties();
+		assertThat(PortalSettingsResponse.builder().build()).hasAllNullFieldsOrProperties();
+		assertThat(new PortalSettingsResponse()).hasAllNullFieldsOrProperties();
 	}
 }

--- a/src/test/java/se/sundsvall/messagingsettings/api/model/SenderInfoResponseTest.java
+++ b/src/test/java/se/sundsvall/messagingsettings/api/model/SenderInfoResponseTest.java
@@ -1,43 +1,61 @@
 package se.sundsvall.messagingsettings.api.model;
 
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 class SenderInfoResponseTest {
 
 	@Test
+	void testBean() {
+		assertThat(SenderInfoResponse.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
 	void builderAndGetters() {
-		final var supportText = "text";
 		final var contactInformationUrl = "url";
 		final var contactInformationPhoneNumber = "phone number";
 		final var contactInformationEmail = "email";
 		final var contactInformationEmailName = "email name";
+		final var organizationNumber = "organizationNumber";
+		final var supportText = "text";
 		final var smsSender = "sender name";
 
 		final var senderInfo = SenderInfoResponse.builder()
-			.withSupportText(supportText)
 			.withContactInformationUrl(contactInformationUrl)
 			.withContactInformationPhoneNumber(contactInformationPhoneNumber)
 			.withContactInformationEmail(contactInformationEmail)
 			.withContactInformationEmailName(contactInformationEmailName)
+			.withOrganizationNumber(organizationNumber)
 			.withSmsSender(smsSender)
+			.withSupportText(supportText)
 			.build();
 
-		assertThat(senderInfo).isInstanceOf(SenderInfoResponse.class);
-		assertThat(senderInfo.getSupportText()).isEqualTo(supportText);
+		assertThat(senderInfo).isInstanceOf(SenderInfoResponse.class).hasNoNullFieldsOrProperties();
 		assertThat(senderInfo.getContactInformationUrl()).isEqualTo(contactInformationUrl);
 		assertThat(senderInfo.getContactInformationPhoneNumber()).isEqualTo(contactInformationPhoneNumber);
 		assertThat(senderInfo.getContactInformationEmail()).isEqualTo(contactInformationEmail);
 		assertThat(senderInfo.getContactInformationEmailName()).isEqualTo(contactInformationEmailName);
+		assertThat(senderInfo.getOrganizationNumber()).isEqualTo(organizationNumber);
 		assertThat(senderInfo.getSmsSender()).isEqualTo(smsSender);
-		assertThat(senderInfo).hasNoNullFieldsOrProperties();
+		assertThat(senderInfo.getSupportText()).isEqualTo(supportText);
 	}
 
 	@Test
 	void builderAndGetters_noValues() {
-		final var entity = SenderInfoResponse.builder().build();
-
-		assertThat(entity).hasAllNullFieldsOrProperties();
+		assertThat(SenderInfoResponse.builder().build()).hasAllNullFieldsOrProperties();
+		assertThat(new SenderInfoResponse()).hasAllNullFieldsOrProperties();
 	}
 }

--- a/src/test/java/se/sundsvall/messagingsettings/integration/db/entity/MessagingSettingsEntityTest.java
+++ b/src/test/java/se/sundsvall/messagingsettings/integration/db/entity/MessagingSettingsEntityTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Test;
-import se.sundsvall.messagingsettings.integration.db.entity.enums.SnailMailMethod;
+import se.sundsvall.messagingsettings.enums.SnailMailMethod;
 
 class MessagingSettingsEntityTest {
 

--- a/src/test/java/se/sundsvall/messagingsettings/integration/db/mapper/EntityMapperTest.java
+++ b/src/test/java/se/sundsvall/messagingsettings/integration/db/mapper/EntityMapperTest.java
@@ -3,70 +3,113 @@ package se.sundsvall.messagingsettings.integration.db.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import se.sundsvall.messagingsettings.enums.SnailMailMethod;
 import se.sundsvall.messagingsettings.integration.db.entity.MessagingSettingsEntity;
 
 class EntityMapperTest {
 
 	@Test
 	void toSenderInfo() {
+		final var contactInformationUrl = "contactInformationUrl";
+		final var contactInformationPhoneNumber = "contactInformationPhoneNumber";
+		final var contactInformationEmail = "contactInformationEmail";
+		final var contactInformationEmailName = "contactInformationEmailName";
+		final var organizationNumber = "organizationNumber";
+		final var smsSender = "smsSender";
+		final var supportText = "supportText";
 		final var entity = MessagingSettingsEntity.builder()
-			.withSupportText("Lorem ipsum dolor sit amet")
-			.withContactInformationUrl("https://domain.tld/")
-			.withContactInformationPhoneNumber("123-98 76 54")
-			.withContactInformationEmail("test@domain.tld")
-			.withContactInformationEmailName("Test Name")
-			.withSmsSender("SK")
+			.withContactInformationUrl(contactInformationUrl)
+			.withContactInformationPhoneNumber(contactInformationPhoneNumber)
+			.withContactInformationEmail(contactInformationEmail)
+			.withContactInformationEmailName(contactInformationEmailName)
+			.withOrganizationNumber(organizationNumber)
+			.withSmsSender(smsSender)
+			.withSupportText(supportText)
 			.build();
-		final var senderInfo = EntityMapper.toSenderInfo(entity);
 
-		assertThat(senderInfo).hasNoNullFieldsOrProperties();
-		assertThat(senderInfo.getSupportText()).isEqualTo(entity.getSupportText());
-		assertThat(senderInfo.getContactInformationUrl()).isEqualTo(entity.getContactInformationUrl());
-		assertThat(senderInfo.getContactInformationPhoneNumber()).isEqualTo(entity.getContactInformationPhoneNumber());
-		assertThat(senderInfo.getContactInformationEmail()).isEqualTo(entity.getContactInformationEmail());
-		assertThat(senderInfo.getContactInformationEmailName()).isEqualTo(entity.getContactInformationEmailName());
-		assertThat(senderInfo.getSmsSender()).isEqualTo(entity.getSmsSender());
+		final var result = EntityMapper.toSenderInfo(entity);
+
+		assertThat(result).hasNoNullFieldsOrProperties();
+		assertThat(result.getContactInformationUrl()).isEqualTo(contactInformationUrl);
+		assertThat(result.getContactInformationPhoneNumber()).isEqualTo(contactInformationPhoneNumber);
+		assertThat(result.getContactInformationEmail()).isEqualTo(contactInformationEmail);
+		assertThat(result.getContactInformationEmailName()).isEqualTo(contactInformationEmailName);
+		assertThat(result.getOrganizationNumber()).isEqualTo(organizationNumber);
+		assertThat(result.getSmsSender()).isEqualTo(smsSender);
+		assertThat(result.getSupportText()).isEqualTo(supportText);
 	}
 
 	@Test
 	void toSenderInfo_withNull() {
-		final var senderInfo = EntityMapper.toSenderInfo(null);
-
-		assertThat(senderInfo).isNull();
+		assertThat(EntityMapper.toSenderInfo(null))
+			.isNull();
 	}
 
 	@Test
 	void toSenderInfo_withNullValues() {
-		final var entity = MessagingSettingsEntity.builder().build();
-		final var senderInfo = EntityMapper.toSenderInfo(entity);
-
-		assertThat(senderInfo).hasAllNullFieldsOrProperties();
+		assertThat(EntityMapper.toSenderInfo(MessagingSettingsEntity.builder().build()))
+			.hasAllNullFieldsOrProperties();
 	}
 
 	@Test
 	void toCallbackEmail() {
-		final var email = "test@domain.tld";
-		final var messagingSettingsEntity = MessagingSettingsEntity.builder()
+		final var email = "email";
+		final var organizationNumber = "organizationNumber";
+		final var entity = MessagingSettingsEntity.builder()
 			.withCallbackEmail(email)
+			.withOrganizationNumber(organizationNumber)
 			.build();
-		final var result = EntityMapper.toCallbackEmail(messagingSettingsEntity);
+
+		final var result = EntityMapper.toCallbackEmail(entity);
 
 		assertThat(result).hasNoNullFieldsOrProperties();
 		assertThat(result.getCallbackEmail()).isEqualTo(email);
+		assertThat(result.getOrganizationNumber()).isEqualTo(organizationNumber);
 	}
 
 	@Test
 	void toCallbackEmail_withNull() {
-		final var callbackEmail = EntityMapper.toCallbackEmail(null);
-
-		assertThat(callbackEmail).isNull();
+		assertThat(EntityMapper.toCallbackEmail(null))
+			.isNull();
 	}
 
 	@Test
 	void toCallbackEmail_withNullValues() {
-		final var messagingSettingsEntity = MessagingSettingsEntity.builder().build();
-		final var callbackEmail = EntityMapper.toCallbackEmail(messagingSettingsEntity);
+		assertThat(EntityMapper.toCallbackEmail(MessagingSettingsEntity.builder().build()))
+			.hasAllNullFieldsOrProperties();
+	}
 
-		assertThat(callbackEmail).hasAllNullFieldsOrProperties();
+	@Test
+	void toPortalSettings() {
+		final var departmentName = "departmentName";
+		final var municipalityId = "municipalityId";
+		final var organizationNumber = "organizationNumber";
+		final var snailMailMethod = SnailMailMethod.EMAIL;
+		final var entity = MessagingSettingsEntity.builder()
+			.withDepartmentName(departmentName)
+			.withMunicipalityId(municipalityId)
+			.withOrganizationNumber(organizationNumber)
+			.withSnailMailMethod(snailMailMethod)
+			.build();
+
+		final var result = EntityMapper.toPortalSettings(entity);
+
+		assertThat(result).hasNoNullFieldsOrProperties();
+		assertThat(result.getDepartmentName()).isEqualTo(departmentName);
+		assertThat(result.getMunicipalityId()).isEqualTo(municipalityId);
+		assertThat(result.getOrganizationNumber()).isEqualTo(organizationNumber);
+		assertThat(result.getSnailMailMethod()).isEqualTo(snailMailMethod);
+	}
+
+	@Test
+	void toPortalSettings_withNull() {
+		assertThat(EntityMapper.toPortalSettings(null))
+			.isNull();
+	}
+
+	@Test
+	void toPortalSettings_withNullValues() {
+		assertThat(EntityMapper.toPortalSettings(MessagingSettingsEntity.builder().build()))
+			.hasAllNullFieldsOrProperties();
 	}
 }


### PR DESCRIPTION
- Extended API responses with organization number attribute
- Extended mapper to include organization number attribute
- Changed package for enum class as it is used both by API and database
- Added missing tests for resource layer
- Updated IT-tests to match updated responses
- Splitted success- and failure resource tests into separate classes

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
